### PR TITLE
fixed crashing auth middleware with no token

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -27,7 +27,7 @@ const auth = async (req, res, next) => {
     } catch (err) {
       next(err);
     }
-  } else throw createError(403, "No token provided");
+  } else next( createError(403, "No token provided") );
 };
 
 module.exports = auth;


### PR DESCRIPTION
Якщо в заголовках відсутній токен, мідлвар auth кидає помилку без перехоплення catch-ем, і це роняє сервер. Поміняв це на проброс цієї помилки в next для подальшого повернення користувачу без краша сервера